### PR TITLE
Make "disable submit button" more specific to freehanddrawing plugin

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@
 #fitem_id_qtype_freehanddrawing_textarea_id_0 {
 		display: block;
 }
-input[type="submit"]:disabled {
+#page-question-type-freehanddrawing input[type="submit"]:disabled {
 	display: none;
 }
 .qtype_freehanddrawing_canvas {


### PR DESCRIPTION
Disabling the submit button on various Moodle forms, causes the button to become hidden. which is not the intended behavior we are looking for in those cases.

It seems to originate in this styles.css file, after installing question type freehanddrawing on our systems.

I am suggesting the above fix, although I am not sure it is the correct fix since I was not sure which submit button you intended to hide. So please see that I am using the correct page id.
